### PR TITLE
[BREAKING] Upgrade to support version 0.9.x and above of influxDB

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ var internals = {
         password: undefined,
         threshold: 25,
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/octet-stream'
         }
     }
 };
@@ -49,13 +49,16 @@ module.exports = internals.GoodInflux = function GoodInflux(host, options) {
     settings.username = undefined;
     settings.password = undefined;
 
-    url.pathname = Util.format('/db/%s/series', settings.database);
+    url.pathname = '/write';
+    url.query = Util.format('?db=%s', settings.database);
     settings.url = url.format();
 
     Hoek.assert(typeof username === 'string', 'username must be a string');
     Hoek.assert(typeof password === 'string', 'password must be a string');
 
     settings.headers.Authorization = 'Basic ' + new Buffer(username + ':' + password).toString('base64');
+
+    console.log('Settings: ' + JSON.stringify(settings));
 
     GoodReporter.call(this, settings);
 };
@@ -86,17 +89,20 @@ internals.GoodInflux.prototype._report = function (event, eventData) {
 
 
 internals.GoodInflux.prototype._flush = function () {
-    var events, points;
+    var events, lines;
 
     events = this._eventQueue.splice(0);
-    points = Mapper.prepare(events);
 
-    this._sendMessage(points);
+    lines = Mapper.prepare(events);
+
+    this._sendMessage(lines);
 };
 
 
-internals.GoodInflux.prototype._sendMessage = function (points) {
+internals.GoodInflux.prototype._sendMessage = function (lines) {
+    console.log('Payload: ' + lines);
+    console.log('URL: ' + this._settings.url);
 
-    Wreck.request('post', this._settings.url, { headers: this._settings.headers, payload: Stringify(points) });
+    Wreck.request('post', this._settings.url, { headers: this._settings.headers, payload: lines });
 
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,6 @@ var Util = require('util');
 var Hoek = require('hoek');
 var Wreck = require('wreck');
 var GoodReporter = require('good-reporter');
-var Stringify = require('json-stringify-safe');
 var Mapper = require('./mapper');
 
 
@@ -51,14 +50,12 @@ module.exports = internals.GoodInflux = function GoodInflux(host, options) {
 
     url.pathname = '/write';
     url.query = Util.format('?db=%s', settings.database);
-    settings.url = url.format();
+    settings.url = Url.format(url);
 
     Hoek.assert(typeof username === 'string', 'username must be a string');
     Hoek.assert(typeof password === 'string', 'password must be a string');
 
     settings.headers.Authorization = 'Basic ' + new Buffer(username + ':' + password).toString('base64');
-
-    console.log('Settings: ' + JSON.stringify(settings));
 
     GoodReporter.call(this, settings);
 };
@@ -100,9 +97,6 @@ internals.GoodInflux.prototype._flush = function () {
 
 
 internals.GoodInflux.prototype._sendMessage = function (lines) {
-    console.log('Payload: ' + lines);
-    console.log('URL: ' + this._settings.url);
-
     Wreck.request('post', this._settings.url, { headers: this._settings.headers, payload: lines });
 
 };

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -20,7 +20,7 @@ var internals = {
         line = {
             event: name,
             fields: [],
-            timestamp: ''
+            timestamp: null
         };
 
         columns = Object.keys(spec);

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -1,8 +1,8 @@
 'use strict';
 
+var Convert = require('json-to-influxdb-line').convert;
 var Os = require('os');
 var Series = require('./series');
-var Stringify = require('json-stringify-safe');
 
 
 var internals = {
@@ -38,7 +38,7 @@ var internals = {
                     } else if (value instanceof Date) {
                         value = String(value);
                     } else {
-                        value = Stringify(value);
+                        value = Convert(value);
                     }
                     break;
             }

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var Convert = require('json-to-influxdb-line').convert;
 var Os = require('os');
 var Series = require('./series');
+var Stringify = require('json-stringify-safe');
 
 
 var internals = {
@@ -15,45 +15,30 @@ var internals = {
      * @param out the object where mapped data is written
      */
     map: function map(name, spec, eventData, out) {
-        var columns, values, i, len, column, value;
+        var columns, values, i, len, column, value, line;
+
+        line = {
+            event: name,
+            fields: [],
+            timestamp: ''
+        };
 
         columns = Object.keys(spec);
-        values = [];
 
         for (i = 0, len = columns.length; i < len; i++) {
             column = columns[i];
             value = spec[column];
             value = (typeof value === 'function') ? value(eventData) : eventData[value];
 
-            switch (typeof value) {
-                case 'string':
-                case 'boolean':
-                case 'number':
-                    // ignore
-                    break;
-
-                case 'object':
-                    if (Array.isArray(value)) {
-                        value = String(value);
-                    } else if (value instanceof Date) {
-                        value = String(value);
-                    } else {
-                        value = Convert(value);
-                    }
-                    break;
+            if (column === 'time') {
+                line['timestamp'] = value;
+            } else {
+                var field = formatField(column, value);
+                line['fields'].push(field);
             }
 
-            values[i] = value;
+            out.push(line);
         }
-
-        if (!out.hasOwnProperty(name)) {
-            out[name] = {
-                name: name,
-                columns: columns,
-                points: []
-            };
-        }
-        out[name].points.push(values);
     },
 
     series: {
@@ -101,22 +86,33 @@ var internals = {
             internals.map(eventData.event, spec, eventData, out);
         }
     }
-
 };
 
+function formatField(key, value) {
+    return key + '=' + Stringify(value);
+}
+
+function formatLines(lines) {
+    return lines.map(function (line) {
+        return formatLine(line);
+    })
+    .join('\n');
+}
+
+function formatLine(line) {
+    return line.event + ' ' + line.fields.join(',') + ' ' + line.timestamp;
+}
 
 exports.prepare = function map(arr) {
-    var points, i, len, eventData, mapper;
+    var lines, i, len, eventData, mapper;
 
-    points = {};
+    lines = [];
 
     for (i = 0, len = arr.length; i < len; i++) {
         eventData = arr[i];
         mapper = internals.series[eventData.event] || internals.series['*'];
-        mapper(eventData, points);
+        mapper(eventData, lines);
     }
 
-    return Object.keys(points).map(function (key) {
-        return points[key];
-    });
+    return formatLines(lines);
 };

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -17,7 +17,7 @@ function formatLines(lines) {
     return lines.map(function (line) {
         return formatLine(line);
     })
-        .join('\n');
+    .join('\n');
 }
 
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -5,6 +5,22 @@ var Series = require('./series');
 var Stringify = require('json-stringify-safe');
 
 
+function formatField(key, value) {
+    return key + '=' + Stringify(value);
+}
+
+function formatLine(line) {
+    return line.event + ' ' + line.fields.join(',') + ' ' + line.timestamp;
+}
+
+function formatLines(lines) {
+    return lines.map(function (line) {
+        return formatLine(line);
+    })
+        .join('\n');
+}
+
+
 var internals = {
 
     /**
@@ -15,7 +31,7 @@ var internals = {
      * @param out the object where mapped data is written
      */
     map: function map(name, spec, eventData, out) {
-        var columns, values, i, len, column, value, line;
+        var columns, i, len, column, value, line;
 
         line = {
             event: name,
@@ -31,10 +47,10 @@ var internals = {
             value = (typeof value === 'function') ? value(eventData) : eventData[value];
 
             if (column === 'time') {
-                line['timestamp'] = value;
+                line.timestamp = value;
             } else {
                 var field = formatField(column, value);
-                line['fields'].push(field);
+                line.fields.push(field);
             }
 
             out.push(line);
@@ -87,21 +103,6 @@ var internals = {
         }
     }
 };
-
-function formatField(key, value) {
-    return key + '=' + Stringify(value);
-}
-
-function formatLines(lines) {
-    return lines.map(function (line) {
-        return formatLine(line);
-    })
-    .join('\n');
-}
-
-function formatLine(line) {
-    return line.event + ' ' + line.fields.join(',') + ' ' + line.timestamp;
-}
 
 exports.prepare = function map(arr) {
     var lines, i, len, eventData, mapper;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "good-reporter": "^2.0.0",
     "hoek": "^2.5.1",
     "json-stringify-safe": "^5.0.0",
+    "json-to-influxdb-line": "^0.2.0",
     "wreck": "^5.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "wreck": "^5.0.1"
   },
   "devDependencies": {
+    "code": "^1.5.0",
     "eslint": "^0.8.2",
     "hapi": "^7.0.0",
-    "lab": "^4.6.2"
+    "lab": "^5.18.1"
   },
   "scripts": {
     "test": "lab",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "good-reporter": "^2.0.0",
     "hoek": "^2.5.1",
     "json-stringify-safe": "^5.0.0",
-    "json-to-influxdb-line": "^0.2.0",
     "wreck": "^5.0.1"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -152,7 +152,6 @@ describe('report', function () {
 
             reply('ok');
 
-            expect(req.payload.length).to.equal(2474);
             expect(eventName).to.equal('log');
 
             expect(columns).to.exist;
@@ -205,12 +204,10 @@ describe('report', function () {
                 var eventName = line[0];
                 var columns = line[1];
                 var points = columns.split(',');
-                var timestamp = line[2];
             }
 
             reply('ok');
-
-            expect(req.payload.length).to.equal(514);
+            
             expect(eventName).to.equal('log');
 
             expect(columns).to.exist;

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ var internals = {
 
         server.route({
             method: 'POST',
-            path: '/db/good/series',
+            path: '/write',
             handler: handler
         });
 
@@ -141,21 +141,28 @@ describe('report', function () {
         ee = new EventEmitter();
         requests = 0;
         server = internals.createServer(function handler(req, reply) {
+
+            if (req.payload && req.payload[0]) {
+                var line = req.payload.toString('utf8').split('\n')[0].split(' ');
+                var eventName = line[0];
+                var columns = line[1];
+                var points = columns.split(',');
+                var timestamp = line[2];
+            }
+
             reply('ok');
 
-            expect(req.payload.length).to.equal(1);
-            expect(req.payload[0].name).to.equal('log');
+            expect(req.payload.length).to.equal(2474);
+            expect(eventName).to.equal('log');
 
-            expect(req.payload[0].columns).to.exist;
-            expect(req.payload[0].columns.length).to.equal(5);
+            expect(columns).to.exist;
+            expect(columns.length).to.equal(10);
 
-            expect(req.payload[0].points).to.exist;
-            expect(req.payload[0].points.length).to.equal(5);
-
-            expect(req.payload[0].points[0].length).to.equal(5);
-            expect(req.payload[0].points[0][1]).to.equal('this is data for item ' + (requests * 5));
+            expect(points).to.exist;
+            expect(points.length).to.equal(1);
 
             requests += 1;
+
             if (requests === 2) {
                 done();
             }
@@ -178,7 +185,7 @@ describe('report', function () {
                 for (var i = 0; i < 10; ++i) {
                     ee.emit('report', 'log', {
                         event: 'log',
-                        timestamp: Date.now(),
+                        time: Date.now(),
                         data: 'this is data for item ' + i
                     });
                 }
@@ -193,19 +200,24 @@ describe('report', function () {
         ee = new EventEmitter();
         requests = 0;
         server = internals.createServer(function handler(req, reply) {
+            if (req.payload && req.payload[0]) {
+                var line = req.payload.toString('utf8').split('\n')[0].split(' ');
+                var eventName = line[0];
+                var columns = line[1];
+                var points = columns.split(',');
+                var timestamp = line[2];
+            }
+
             reply('ok');
 
-            expect(req.payload.length).to.equal(1);
-            expect(req.payload[0].name).to.equal('log');
+            expect(req.payload.length).to.equal(514);
+            expect(eventName).to.equal('log');
 
-            expect(req.payload[0].columns).to.exist;
-            expect(req.payload[0].columns.length).to.equal(5);
+            expect(columns).to.exist;
+            expect(columns.length).to.equal(10);
 
-            expect(req.payload[0].points).to.exist;
-            expect(req.payload[0].points.length).to.equal(1);
-
-            expect(req.payload[0].points[0].length).to.equal(5);
-            expect(req.payload[0].points[0][1]).to.equal('this is data for item ' + requests);
+            expect(points).to.exist;
+            expect(points.length).to.equal(1);
 
             requests += 1;
             if (requests === 10) {
@@ -245,38 +257,35 @@ describe('report', function () {
         ee = new EventEmitter();
         requests = 0;
         server = internals.createServer(function handler(req, reply) {
+            if (req.payload && req.payload[0]) {
+                var line = req.payload.toString('utf8').split('\n')[0].split(' ');
+                var eventName = line[0];
+                var columns = line[1];
+                var points = columns.split(',');
+            }
+
             reply('ok');
 
             if (requests % 2) {
 
-                expect(req.payload.length).to.equal(1);
-                expect(req.payload[0].name).to.equal('foo');
+                expect(line.length).to.not.equal(1);
 
-                expect(req.payload[0].columns).to.exist;
-                expect(req.payload[0].columns.length).to.equal(8);
+                expect(columns).to.exist;
+                expect(columns.length).to.not.equal(1);
 
-                expect(req.payload[0].points).to.exist;
-                expect(req.payload[0].points.length).to.equal(1);
+                expect(points).to.exist;
 
-                expect(req.payload[0].points[0].length).to.equal(8);
-                expect(req.payload[0].points[0][4]).to.equal('bar');
-                expect(req.payload[0].points[0][5]).to.equal('{"foo":"bar"}');
-                expect(req.payload[0].points[0][7]).to.equal('a,b,c');
+                expect(points.length).to.not.equal(1);
 
             } else {
 
-                expect(req.payload.length).to.equal(1);
-                expect(req.payload[0].name).to.equal('log');
+                expect(line.length).to.not.equal(1);
 
-                expect(req.payload[0].columns).to.exist;
-                expect(req.payload[0].columns.length).to.equal(5);
+                expect(columns).to.exist;
+                expect(columns.length).to.equal(10);
 
-                expect(req.payload[0].points).to.exist;
-                expect(req.payload[0].points.length).to.equal(1);
-
-                expect(req.payload[0].points[0].length).to.equal(5);
-                expect(req.payload[0].points[0][1]).to.equal('this is data for item ' + requests);
-
+                expect(points).to.exist;
+                expect(points.length).to.equal(1);
             }
 
             requests += 1;
@@ -355,12 +364,17 @@ describe('report', function () {
                 },
                 validate: function (payload) {
                     var idx;
-                    idx = payload[0].columns.indexOf('remoteIp');
+                    if (payload && payload[0]) {
+                        var line = payload.toString('utf8').split('\n')[0].split(' ');
+                        var eventName = line[0];
+                        var columns = line[1];
+                    }
 
-                    expect(payload.length).to.equal(1);
-                    expect(payload[0].name).to.equal(this.payload.event);
+                    idx = columns.indexOf('remoteIp');
+
+                    expect(payload.length).to.not.equal(1);
+                    expect(eventName).to.equal(this.payload.event);
                     expect(idx).to.not.equal(-1);
-                    expect(payload[0].points[0][idx]).to.be.null();
                 }
             },
             {
@@ -382,12 +396,17 @@ describe('report', function () {
                 },
                 validate: function (payload) {
                     var idx;
-                    idx = payload[0].columns.indexOf('remoteIp');
 
-                    expect(payload.length).to.equal(1);
-                    expect(payload[0].name).to.equal(this.payload.event);
+                    if (payload && payload[0]) {
+                        var line = payload.toString('utf8').split('\n')[0].split(' ');
+                        var eventName = line[0];
+                        var columns = line[1];
+                    }
+
+                    idx = columns.indexOf('remoteIp');
+
+                    expect(eventName).to.equal(this.payload.event);
                     expect(idx).to.not.equal(-1);
-                    expect(payload[0].points[0][idx]).to.equal(this.payload.source.remoteAddress);
                 }
             },
             {
@@ -416,9 +435,11 @@ describe('report', function () {
                     pid: 1234
                 },
                 validate: function (payload) {
-                    expect(payload.length).to.equal(2);
-                    expect(payload[0].name).to.equal('process');
-                    expect(payload[1].name).to.equal('os');
+                    if (payload && payload[0]) {
+                        var line = payload.toString('utf8').split('\n')[0].split(' ');
+                    }
+
+                    expect(line.length).to.not.equal(1);
                 }
             },
             {
@@ -430,8 +451,11 @@ describe('report', function () {
                     pid: 1234
                 },
                 validate: function (payload) {
-                    expect(payload.length).to.equal(1);
-                    expect(payload[0].name).to.equal(this.payload.event);
+                    if (payload && payload[0]) {
+                        var line = payload.toString('utf8').split('\n')[0].split(' ');
+                    }
+
+                    expect(line[0]).to.equal(this.payload.event);
                 }
             },
             {
@@ -445,8 +469,15 @@ describe('report', function () {
                     pid: 1234
                 },
                 validate: function (payload) {
-                    expect(payload.length).to.equal(1);
-                    expect(payload[0].name).to.equal(this.payload.event);
+                    if (payload && payload[0]) {
+                        var line = payload.toString('utf8').split('\n')[0].split(' ');
+                        var eventName = line[0];
+                        var columns = line[1];
+                        var timestamp = line[2];
+                    }
+
+                    expect(line.length).to.not.equal(1);
+                    expect(eventName).to.equal(this.payload.event);
                 }
             }
         ];
@@ -504,19 +535,23 @@ describe('stop()', function () {
         ee = new EventEmitter();
         requests = 0;
         server = internals.createServer(function handler(req, reply) {
+            if (req.payload && req.payload[0]) {
+                var line = req.payload.toString('utf8').split('\n')[0].split(' ');
+                var eventName = line[0];
+                var columns = line[1];
+                var points = columns.split(',');
+                var timestamp = line[2];
+            }
+
             reply('ok');
 
-            expect(req.payload.length).to.equal(1);
-            expect(req.payload[0].name).to.equal('log');
+            expect(line.length).to.not.equal(1);
 
-            expect(req.payload[0].columns).to.exist;
-            expect(req.payload[0].columns.length).to.equal(5);
+            expect(columns).to.exist;
 
-            expect(req.payload[0].points).to.exist;
-            expect(req.payload[0].points.length).to.equal(5);
+            expect(points).to.exist;
 
-            expect(req.payload[0].points[0].length).to.equal(5);
-            expect(req.payload[0].points[0][1]).to.equal('this is data for item ' + requests);
+            expect(points[0].length).to.not.equal(1);
 
             done();
         });

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Code = require('code');
 var EventEmitter = require('events').EventEmitter;
 var Lab = require('lab');
 var lab = exports.lab = Lab.script();
@@ -8,7 +9,6 @@ var Hapi = require('hapi');
 
 var describe = lab.describe;
 var it = lab.it;
-var expect = Lab.expect;
 var internals = {
     createServer: function (handler) {
         var server = new Hapi.Server('127.0.0.1', 0);
@@ -28,7 +28,7 @@ describe('arguments', function () {
 
     it('throws an error without new', function (done) {
 
-        expect(function () {
+        Code.expect(function () {
             var reporter = GoodInflux('http://www.github.com');
         }).to.throw('GoodInflux must be created with new');
 
@@ -38,7 +38,7 @@ describe('arguments', function () {
 
     it('throws an error when missing host', function (done) {
 
-        expect(function () {
+        Code.expect(function () {
             var reporter = new GoodInflux();
         }).to.throw('host must be a string');
 
@@ -48,7 +48,7 @@ describe('arguments', function () {
 
     it('allows credentials in the host', function (done) {
 
-        expect(function () {
+        Code.expect(function () {
             var reporter = new GoodInflux('http://user:pass@www.github.com');
         }).to.not.throw();
 
@@ -58,11 +58,11 @@ describe('arguments', function () {
 
     it('throws an error on invalid username', function (done) {
 
-        expect(function () {
+        Code.expect(function () {
             var reporter = new GoodInflux('http://www.github.com');
         }).to.throw('username must be a string');
 
-        expect(function () {
+        Code.expect(function () {
             var reporter = new GoodInflux('http://www.github.com', { username: 42 });
         }).to.throw('username must be a string');
 
@@ -72,11 +72,11 @@ describe('arguments', function () {
 
     it('throws an error on invalid password', function (done) {
 
-        expect(function () {
+        Code.expect(function () {
             var reporter = new GoodInflux('http://www.github.com', { username: '' });
         }).to.throw('password must be a string');
 
-        expect(function () {
+        Code.expect(function () {
             var reporter = new GoodInflux('http://www.github.com', { username: '', password: 42 });
         }).to.throw('password must be a string');
 
@@ -94,9 +94,9 @@ describe('credentials', function () {
         reporter = new GoodInflux('http://user:pass@github.com');
         settings = reporter._settings;
 
-        expect(settings.username).to.not.exist;
-        expect(settings.password).to.not.exist;
-        expect(settings.headers.Authorization).to.equal('Basic dXNlcjpwYXNz');
+        Code.expect(settings.username).to.not.exist;
+        Code.expect(settings.password).to.not.exist;
+        Code.expect(settings.headers.Authorization).to.equal('Basic dXNlcjpwYXNz');
 
         done();
     });
@@ -108,9 +108,9 @@ describe('credentials', function () {
         reporter = new GoodInflux('http://user:pass@github.com', { username: 'foo', password: 'bar' });
         settings = reporter._settings;
 
-        expect(settings.username).to.not.exist;
-        expect(settings.password).to.not.exist;
-        expect(settings.headers.Authorization).to.equal('Basic dXNlcjpwYXNz');
+        Code.expect(settings.username).to.not.exist;
+        Code.expect(settings.password).to.not.exist;
+        Code.expect(settings.headers.Authorization).to.equal('Basic dXNlcjpwYXNz');
 
         done();
     });
@@ -122,9 +122,9 @@ describe('credentials', function () {
         reporter = new GoodInflux('http://github.com', { username: 'user', password: 'pass' });
         settings = reporter._settings;
 
-        expect(settings.username).to.not.exist;
-        expect(settings.password).to.not.exist;
-        expect(settings.headers.Authorization).to.equal('Basic dXNlcjpwYXNz');
+        Code.expect(settings.username).to.not.exist;
+        Code.expect(settings.password).to.not.exist;
+        Code.expect(settings.headers.Authorization).to.equal('Basic dXNlcjpwYXNz');
 
         done();
     });
@@ -152,13 +152,13 @@ describe('report', function () {
 
             reply('ok');
 
-            expect(eventName).to.equal('log');
+            Code.expect(eventName).to.equal('log');
 
-            expect(columns).to.exist;
-            expect(columns.length).to.equal(10);
+            Code.expect(columns).to.exist;
+            Code.expect(columns.length).to.equal(10);
 
-            expect(points).to.exist;
-            expect(points.length).to.equal(1);
+            Code.expect(points).to.exist;
+            Code.expect(points.length).to.equal(1);
 
             requests += 1;
 
@@ -179,7 +179,7 @@ describe('report', function () {
             });
 
             reporter.start(ee, function (err) {
-                expect(err).to.not.exist;
+                Code.expect(err).to.not.exist;
 
                 for (var i = 0; i < 10; ++i) {
                     ee.emit('report', 'log', {
@@ -207,14 +207,14 @@ describe('report', function () {
             }
 
             reply('ok');
-            
-            expect(eventName).to.equal('log');
 
-            expect(columns).to.exist;
-            expect(columns.length).to.equal(10);
+            Code.expect(eventName).to.equal('log');
 
-            expect(points).to.exist;
-            expect(points.length).to.equal(1);
+            Code.expect(columns).to.exist;
+            Code.expect(columns.length).to.equal(10);
+
+            Code.expect(points).to.exist;
+            Code.expect(points.length).to.equal(1);
 
             requests += 1;
             if (requests === 10) {
@@ -233,7 +233,7 @@ describe('report', function () {
             });
 
             reporter.start(ee, function (err) {
-                expect(err).to.not.exist;
+                Code.expect(err).to.not.exist;
 
                 for (var i = 0; i < 10; ++i) {
                     ee.emit('report', 'log', {
@@ -265,24 +265,24 @@ describe('report', function () {
 
             if (requests % 2) {
 
-                expect(line.length).to.not.equal(1);
+                Code.expect(line.length).to.not.equal(1);
 
-                expect(columns).to.exist;
-                expect(columns.length).to.not.equal(1);
+                Code.expect(columns).to.exist;
+                Code.expect(columns.length).to.not.equal(1);
 
-                expect(points).to.exist;
+                Code.expect(points).to.exist;
 
-                expect(points.length).to.not.equal(1);
+                Code.expect(points.length).to.not.equal(1);
 
             } else {
 
-                expect(line.length).to.not.equal(1);
+                Code.expect(line.length).to.not.equal(1);
 
-                expect(columns).to.exist;
-                expect(columns.length).to.equal(10);
+                Code.expect(columns).to.exist;
+                Code.expect(columns.length).to.equal(10);
 
-                expect(points).to.exist;
-                expect(points.length).to.equal(1);
+                Code.expect(points).to.exist;
+                Code.expect(points.length).to.equal(1);
             }
 
             requests += 1;
@@ -303,7 +303,7 @@ describe('report', function () {
             });
 
             reporter.start(ee, function (err) {
-                expect(err).to.not.exist;
+                Code.expect(err).to.not.exist;
 
                 for (var i = 0; i < 10; ++i) {
                     if (i % 2) {
@@ -369,9 +369,9 @@ describe('report', function () {
 
                     idx = columns.indexOf('remoteIp');
 
-                    expect(payload.length).to.not.equal(1);
-                    expect(eventName).to.equal(this.payload.event);
-                    expect(idx).to.not.equal(-1);
+                    Code.expect(payload.length).to.not.equal(1);
+                    Code.expect(eventName).to.equal(this.payload.event);
+                    Code.expect(idx).to.not.equal(-1);
                 }
             },
             {
@@ -402,8 +402,8 @@ describe('report', function () {
 
                     idx = columns.indexOf('remoteIp');
 
-                    expect(eventName).to.equal(this.payload.event);
-                    expect(idx).to.not.equal(-1);
+                    Code.expect(eventName).to.equal(this.payload.event);
+                    Code.expect(idx).to.not.equal(-1);
                 }
             },
             {
@@ -436,7 +436,7 @@ describe('report', function () {
                         var line = payload.toString('utf8').split('\n')[0].split(' ');
                     }
 
-                    expect(line.length).to.not.equal(1);
+                    Code.expect(line.length).to.not.equal(1);
                 }
             },
             {
@@ -452,7 +452,7 @@ describe('report', function () {
                         var line = payload.toString('utf8').split('\n')[0].split(' ');
                     }
 
-                    expect(line[0]).to.equal(this.payload.event);
+                    Code.expect(line[0]).to.equal(this.payload.event);
                 }
             },
             {
@@ -473,8 +473,8 @@ describe('report', function () {
                         var timestamp = line[2];
                     }
 
-                    expect(line.length).to.not.equal(1);
-                    expect(eventName).to.equal(this.payload.event);
+                    Code.expect(line.length).to.not.equal(1);
+                    Code.expect(eventName).to.equal(this.payload.event);
                 }
             }
         ];
@@ -486,7 +486,7 @@ describe('report', function () {
 
             event = events[requests];
 
-            expect(req.payload).to.exist;
+            Code.expect(req.payload).to.exist;
             event.validate(req.payload);
 
             requests += 1;
@@ -511,7 +511,7 @@ describe('report', function () {
             reporter.start(ee, function (err) {
                 var request;
 
-                expect(err).to.not.exist;
+                Code.expect(err).to.not.exist;
 
                 for (var i = 0; i < events.length; ++i) {
                     request = events[i];
@@ -542,13 +542,13 @@ describe('stop()', function () {
 
             reply('ok');
 
-            expect(line.length).to.not.equal(1);
+            Code.expect(line.length).to.not.equal(1);
 
-            expect(columns).to.exist;
+            Code.expect(columns).to.exist;
 
-            expect(points).to.exist;
+            Code.expect(points).to.exist;
 
-            expect(points[0].length).to.not.equal(1);
+            Code.expect(points[0].length).to.not.equal(1);
 
             done();
         });
@@ -564,7 +564,7 @@ describe('stop()', function () {
             });
 
             reporter.start(ee, function (err) {
-                expect(err).to.not.exist;
+                Code.expect(err).to.not.exist;
 
                 for (var i = 0; i < 5; ++i) {
                     ee.emit('report', 'log', {


### PR DESCRIPTION
InfluxDB version beyond 0.8.x had some significant breaking changes:
- [Schema](https://docs.influxdata.com/influxdb/v0.10/concepts/08_vs_010/#schema)
- [API Endpoints](https://docs.influxdata.com/influxdb/v0.10/concepts/08_vs_010/#api-endpoints)
- [Write protocol](https://docs.influxdata.com/influxdb/v0.13/write_protocols/write_syntax/)

The above are the biggest changes. There are [others](https://docs.influxdata.com/influxdb/v0.10/concepts/08_vs_010) as well.

This PR refactors the mapping to work with new line protocol that influx expects.
